### PR TITLE
Simplify outputs from `info` command + minor formatting cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha": "^9.2.1",
     "pkg": "^5.5.2",
     "prettier": "^2.5.1",
+    "process-utils": "^4.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0"

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
-const { isEmpty, path } = require('ramda');
+const { isEmpty, path, pick } = require('ramda');
 const { Graph, alg } = require('graphlib');
 const traverse = require('traverse');
 
@@ -262,13 +262,22 @@ class ComponentsService {
     await this.invokeComponentsInParallel('logs', options);
   }
 
-  async info() {
+  async info(options) {
     const outputs = await this.context.stateStorage.readComponentsOutputs();
 
     if (isEmpty(outputs)) {
       throw new Error('Could not find any deployed service');
-    } else {
+    } else if (options.verbose) {
       this.context.renderOutputs(outputs);
+    } else {
+      const filteredOutputs = {};
+      for (const [key, val] of Object.entries(outputs)) {
+        filteredOutputs[key] = pick(
+          ['region', 'function', 'functions', 'endpoint', 'endpoints'],
+          val
+        );
+      }
+      this.context.renderOutputs(filteredOutputs);
     }
   }
 

--- a/src/Context.js
+++ b/src/Context.js
@@ -52,8 +52,10 @@ class Context {
     if (typeof outputs !== 'object' || Object.keys(outputs).length === 0) {
       return;
     }
+
     safeWrite(
       `\n${prettyoutput(outputs, {
+        alignKeyValues: false,
         colors: {
           keys: 'gray',
           dash: 'gray',

--- a/src/cli/output.js
+++ b/src/cli/output.js
@@ -14,7 +14,9 @@ function safeWrite(text, stream, prefix = '') {
     stream.write(`${prefix}${line}`);
     // But maybe the line already contained content (e.g. a progress)
     // so we clear the rest of line, up till its end (on the right side)
-    stream.clearLine(1);
+    if (stream.clearLine) {
+      stream.clearLine(1);
+    }
     // Then we can add a line return
     stream.write('\n');
   }

--- a/src/utils/telemetry/send.js
+++ b/src/utils/telemetry/send.js
@@ -19,7 +19,7 @@ const processResponseBody = async (response, ids, context) => {
   try {
     result = await response.json();
   } catch (error) {
-    context.logger.verbose(`Response processing error for ${ids || '<no id>'}`, error);
+    context.logger.verbose(`Response processing error for ${ids || '<no id>'}: ${error}`);
     return null;
   }
   return result;
@@ -38,12 +38,12 @@ async function request(payload, { ids, timeout, context } = {}) {
       body,
     });
   } catch (networkError) {
-    context.logger.verbose('Request network error', networkError);
+    context.logger.verbose(`Request network error: ${networkError}`);
     return null;
   }
 
   if (response.status < 200 || response.status >= 300) {
-    context.logger.verbose('Unexpected request response', response);
+    context.logger.verbose(`Unexpected request response: ${response}`);
     return processResponseBody(response, ids, context);
   }
 
@@ -55,7 +55,7 @@ async function request(payload, { ids, timeout, context } = {}) {
       try {
         await fsp.unlink(cachePath);
       } catch (error) {
-        context.logger.verbose(`Could not remove cache file ${id}`, error);
+        context.logger.verbose(`Could not remove cache file ${id}: ${error}`);
       }
     })
   );
@@ -70,7 +70,7 @@ async function send(context) {
     dirFilenames = await fsp.readdir(cacheDirPath);
   } catch (readdirError) {
     if (readdirError.code !== 'ENOENT') {
-      context.logger.verbose('Cannot access cache dir', readdirError);
+      context.logger.verbose(`Cannot access cache dir: ${readdirError}`);
     }
     return null;
   }
@@ -84,12 +84,12 @@ async function send(context) {
           data = await fse.readJson(join(cacheDirPath, dirFilename));
         } catch (readJsonError) {
           if (readJsonError.code === 'ENOENT') return null; // Race condition
-          context.logger.verbose(`Cannot read cache file: ${dirFilename}`, readJsonError);
+          context.logger.verbose(`Cannot read cache file: ${dirFilename}: ${readJsonError}`);
           const cacheFile = join(cacheDirPath, dirFilename);
           try {
             return await fsp.unlink(cacheFile);
           } catch (error) {
-            context.logger.verbose(`Could not remove cache file ${dirFilename}`, error);
+            context.logger.verbose(`Could not remove cache file ${dirFilename}: ${error}`);
           }
         }
 
@@ -102,14 +102,14 @@ async function send(context) {
             };
           }
         } else {
-          context.logger.verbose(`Invalid cached data ${dirFilename}`, data);
+          context.logger.verbose(`Invalid cached data ${dirFilename}: ${data}`);
         }
 
         const cacheFile = join(cacheDirPath, dirFilename);
         try {
           return await fsp.unlink(cacheFile);
         } catch (error) {
-          context.logger.verbose(`Could not remove cache file ${dirFilename}`, error);
+          context.logger.verbose(`Could not remove cache file ${dirFilename}: ${error}`);
         }
         return null;
       })


### PR DESCRIPTION
Closes: https://github.com/serverless/compose/issues/15

I've changed the approach a little bit in comparison to the proposal - instead of storing metadata at state level it is currently filtered out by the specific fields (filtering on state-level turned out to be quite cumbersome when it comes to representing state so I decided it's maybe not the best idea). In the future, I think we need to consider invoking `info` for each component separately for example and representing data this way - I think each component author should have a say on what data they want to expose in such command (it's definitely not going to be all outputs all the time).

btw - I've left the region because otherwise we might end up with 0 outputs to actually show in case of very simple services and I think we have to show *something* for all of them - what do you think @mnapoli ?

I've additionally changed the formatting a little bit - previous automatic alignment of `prettyoutput` was looking terrible imo.

Simple:
![E9E90BEF-5CE0-41DB-A1AE-E3C19A65424C](https://user-images.githubusercontent.com/17499590/158847460-0d5f1cb1-96f4-4d6f-8deb-a2b4ba39074f.jpeg)

Verbose:
![40ABCAF8-DC4B-42E0-AE02-9A9A3CCB270E](https://user-images.githubusercontent.com/17499590/158847560-97a234aa-4cc7-48c5-a25f-0b6a0be197ba.jpeg)

