### PR TITLE
fix: Keep `ServerlessDeploymentBucketName` in outputs

### DIFF
--- a/components/framework/serverless.js
+++ b/components/framework/serverless.js
@@ -203,7 +203,6 @@ class ServerlessFramework extends Component {
       ...outputs['Stack Outputs'],
     };
     delete outputs['Stack Outputs'];
-    delete outputs.ServerlessDeploymentBucketName; // useless info
 
     return outputs;
   }


### PR DESCRIPTION
Addresses: https://github.com/serverless/compose/issues/18