### PR TITLE
feat: Introduce `refresh-outputs` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ On top of `serverless-compose deploy`, the following commands can be run globall
 
 - `serverless-compose info` to view all services outputs
 - `serverless-compose remove` to remove all services
+- `serverless-compose refresh-outputs` to refresh outputs of all services
 - `serverless-compose logs` to fetch logs from **all functions across all services**
 
 For example, it is possible to tail logs for all functions at once:
@@ -245,6 +246,14 @@ In these cases, you must run all commands from the root: `serverless-compose ser
 Unless documented here, expect any `serverless.yml` feature to not be supported in `serverless-compose.yml`. For example, it is not possible to include plugins or use `serverless.yml` variables (like `${env:`, `${opt:`, etc.) inside `serverless-compose.yml`.
 
 Feel free to open an issue if you need a feature that isn't supported at the moment.
+
+## Refreshing outputs of already deployed services
+
+If you need to refresh outputs of services that you already deployed previously, e.g. from different development machine, you can do it with the following command:
+
+```
+serverless-compose refresh-outputs
+```
 
 ## Removing services
 

--- a/components/framework/serverless.js
+++ b/components/framework/serverless.js
@@ -126,6 +126,12 @@ class ServerlessFramework extends Component {
     }
   }
 
+  async refreshOutputs() {
+    this.startProgress('refreshing outputs');
+    await this.updateOutputs(await this.retrieveOutputs());
+    this.successProgress('outputs refreshed');
+  }
+
   /**
    * @return {Promise<{ stdout: string, stderr: string }>}
    */

--- a/src/Component.js
+++ b/src/Component.js
@@ -60,6 +60,10 @@ class Component {
     // To be implemented by components
   }
 
+  async refreshOutputs() {
+    // To be implemented by components
+  }
+
   async save() {
     await this.context.stateStorage.writeComponentState(this.id, this.state);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,13 @@ const resolveConfigurationVariables = async (configuration, stage) => {
   return resolvedConfiguration;
 };
 
+const mapMethodName = (methodName) => {
+  if (methodName === 'refresh-outputs') {
+    return 'refreshOutputs';
+  }
+  return methodName;
+};
+
 const runComponents = async () => {
   if (args.help || args._[0] === 'help') {
     await renderHelp();
@@ -131,7 +138,6 @@ const runComponents = async () => {
     return;
   }
   method = method.join(':');
-
   options = args;
 
   if (options.service) {
@@ -143,6 +149,9 @@ const runComponents = async () => {
     method = methods.join(':');
   }
   delete options._; // remove the method name if any
+
+  // Map CLI method names to internal method names
+  method = mapMethodName(method);
 
   const serverlessFile = getServerlessFile(process.cwd());
 

--- a/src/render-help.js
+++ b/src/render-help.js
@@ -38,6 +38,14 @@ const commands = [
       tail: 'Tail the log in real time',
     },
   },
+  {
+    command: 'refreshOutputs',
+    description: 'Refresh the outptus for all services',
+    options: {
+      verbose: 'Show verbose logs',
+      stage: 'Stage of the service',
+    },
+  },
 ];
 
 const formatCommand = (command) => {


### PR DESCRIPTION
Support refreshing outputs. At the moment, it expects the components to implement the `refreshOutputs` method, however, we might need to reconsider that when we have components that will need to rely on external state

Closes: #45 