### PR TITLE
feat: Format error messages in a consistent manner

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -34,7 +34,7 @@ class Component {
 
     if (typeof this.outputs === 'function') {
       throw new ServerlessError(
-        `Cannot declare a "outputs" function in component "${this.id}"`,
+        `Cannot declare an "outputs" function in component "${this.id}"`,
         'INVALID_COMPONENT_OUTPUTS'
       );
     }

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -29,7 +29,7 @@ const resolveObject = (object, context) => {
 
       if (referencedPropertyValue === undefined) {
         throw new ServerlessError(
-          `the variable ${match} cannot be resolved: the referenced output does not exist`,
+          `The variable "${match}" cannot be resolved: the referenced output does not exist`,
           'REFERENCED_OUTPUT_DOES_NOT_EXIST'
         );
       }
@@ -40,7 +40,7 @@ const resolveObject = (object, context) => {
         newValue = newValue.replace(match, referencedPropertyValue);
       } else {
         throw new ServerlessError(
-          'the referenced substring is not a string',
+          'The referenced substring is not a string',
           'REFERENCED_SUBSTRING_NOT_A_STRING'
         );
       }
@@ -77,7 +77,7 @@ const getAllComponents = async (obj = {}) => {
         const localComponentPath = resolve(process.cwd(), val.component, 'serverless.js');
         if (!(await utils.fileExists(localComponentPath))) {
           throw new ServerlessError(
-            `No serverless.js file found in ${val.component}`,
+            `The component "${val.component}" (used by service "${key}") is invalid: no serverless.js file found`,
             'MISSING_SERVERLESS_FILE_IN_COMPONENT_PATH'
           );
         }
@@ -92,7 +92,7 @@ const getAllComponents = async (obj = {}) => {
         };
       } else {
         throw new ServerlessError(
-          `Unrecognized component: ${val.component}`,
+          `Unrecognized component type "${val.component}" for service "${key}"`,
           'UNRECOGNIZED_COMPONENT'
         );
       }
@@ -129,7 +129,7 @@ const validateComponents = async (components) => {
           .map((item) => `"${item[0]}"`)
           .join(
             ', '
-          )}. This is currently not supported because deploying such services in parallel generates packages in the same ".serverless/" directory which can cause conflicts.`,
+          )}. This is currently not supported because deploying the same service in parallel generates packages in the same ".serverless/" directory which can cause conflicts.`,
         'DUPLICATED_COMPONENT_DEFINITION'
       );
     }
@@ -148,7 +148,7 @@ const setDependencies = (allComponents) => {
 
           if (!allComponents[referencedComponent]) {
             throw new ServerlessError(
-              `the referenced service in expression ${match} does not exist`,
+              `The service "${referencedComponent}" does not exist. It is referenced by "${alias}" in expression "${match}".`,
               'REFERENCED_COMPONENT_DOES_NOT_EXIST'
             );
           }
@@ -305,7 +305,7 @@ class ComponentsService {
 
     if (isEmpty(outputs)) {
       throw new ServerlessError(
-        'Could not find any deployed service',
+        'Could not find any deployed service.\nYou can deploy the project via "serverless-compose deploy".\nIf the project is already deployed, you can synchronize your local state via "serverless-compose refresh-outputs".',
         'NO_DEPLOYED_SERVICES_FOUND'
       );
     } else if (options.verbose) {
@@ -327,7 +327,7 @@ class ComponentsService {
 
     const component = this.allComponents?.[componentName]?.instance;
     if (component === undefined) {
-      throw new ServerlessError(`Unknown service ${componentName}`, 'COMPONENT_NOT_FOUND');
+      throw new ServerlessError(`Unknown service "${componentName}"`, 'COMPONENT_NOT_FOUND');
     }
     component.logVerbose(`Invoking "${command}" on service "${componentName}"`);
 
@@ -354,7 +354,7 @@ class ComponentsService {
       // Custom command: the handler is defined in the component's `commands` property
       if (!component.commands?.[command]) {
         throw new ServerlessError(
-          `No command ${command} on service ${componentName}`,
+          `No command "${command}" on service "${componentName}"`,
           'COMPONENT_COMMAND_NOT_FOUND'
         );
       }
@@ -435,7 +435,7 @@ class ComponentsService {
           // Check the existence of the method on the component
           if (typeof component[method] !== 'function') {
             throw new ServerlessError(
-              `Missing method ${method} on service ${alias}`,
+              `Missing method "${method}" on service "${alias}"`,
               'COMPONENT_COMMAND_NOT_FOUND'
             );
           }

--- a/src/handle-error.js
+++ b/src/handle-error.js
@@ -27,7 +27,7 @@ module.exports = async (exception, logger) => {
   const errorMsg = stripAnsi(
     exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message
   );
-  logger.writeText(`${colors.red('Error')}:\n${errorMsg}`);
+  logger.writeText(`${colors.red('Error:')}\n${errorMsg}`);
 
   process.exitCode = 1;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ const getConfiguration = async (template) => {
       !(await utils.fileExists(template))
     ) {
       throw new ServerlessError(
-        'the referenced template path does not exist',
+        'The referenced template path does not exist',
         'REFERENCED_TEMPLATE_PATH_DOES_NOT_EXIST'
       );
     }
@@ -121,7 +121,7 @@ const getConfiguration = async (template) => {
     return utils.readFile(template);
   } else if (typeof template !== 'object') {
     throw new ServerlessError(
-      'the template input could either be an object, or a string path to a template file',
+      'The template input could either be an object, or a string path to a template file',
       'INVALID_TEMPLATE_FORMAT'
     );
   }
@@ -148,7 +148,7 @@ const resolveConfigurationVariables = async (configuration, stage) => {
           const referencedPropertyPath = match.substring(2, match.length - 1).split(':');
           if (process.env[referencedPropertyPath[1]] == null) {
             throw new ServerlessError(
-              `Referenced environment variable "${referencedPropertyPath[1]}" is not defined.`,
+              `The environment variable "${referencedPropertyPath[1]}" is referenced but is not defined`,
               'CANNOT_FIND_ENVIRONMENT_VARIABLE'
             );
           }
@@ -181,7 +181,7 @@ const runComponents = async () => {
     await spawnExt('serverless', ['--version']);
   } catch (err) {
     throw new ServerlessError(
-      'Could not find Serverless Framework installation. Ensure Serverless Framework is installed before continuing.',
+      'Could not find the Serverless Framework CLI. Ensure Serverless Framework is installed before continuing.\nhttps://serverless.com/framework/docs/getting-started',
       'SERVERLESS_COMMAND_NOT_AVAILABLE'
     );
   }
@@ -216,14 +216,14 @@ const runComponents = async () => {
 
   if (!serverlessFile) {
     throw new ServerlessError(
-      'No serverless-compose.yml file found.',
+      'No serverless-compose.yml file found',
       'CONFIGURATION_FILE_NOT_FOUND'
     );
   }
 
   if (!isComponentsTemplate(serverlessFile)) {
     throw new ServerlessError(
-      'serverless-compose.yml file does not contain valid serverless-compose configuration',
+      'serverless-compose.yml does not contain valid Serverless Compose configuration.\nRead about Serverless Compose in the documentation: https://github.com/serverless/compose',
       'INVALID_CONFIGURATION'
     );
   }
@@ -253,7 +253,7 @@ const runComponents = async () => {
       await componentsService.invokeComponentCommand(componentName, method, options);
     } else {
       if (typeof componentsService[method] !== 'function') {
-        throw new ServerlessError(`Command ${method} not found`, 'COMMAND_NOT_FOUND');
+        throw new ServerlessError(`Command "${method}" not found`, 'COMMAND_NOT_FOUND');
       }
       await componentsService[method](options);
     }

--- a/test/unit/src/components-service.test.js
+++ b/test/unit/src/components-service.test.js
@@ -117,7 +117,7 @@ describe('test/unit/src/components-service.test.js', () => {
     componentsService = new ComponentsService(context, configuration);
 
     await expect(componentsService.init()).to.eventually.be.rejectedWith(
-      'Service "resources" has the same "path" as the following services: "duplicated". This is currently not supported because deploying such services in parallel generates packages in the same ".serverless/" directory which can cause conflicts.'
+      'Service "resources" has the same "path" as the following services: "duplicated". This is currently not supported because deploying the same service in parallel generates packages in the same ".serverless/" directory which can cause conflicts.'
     );
   });
 


### PR DESCRIPTION
This builds on #58 to format error messages consistently:

- always start with an upper case (because now  `Error:` is on a different line)
- quote all variables/names with `"`
- rewrite some messages to make them more actionable