### PR TITLE
Detailed error messages for invalid command and options

### DIFF
--- a/src/handle-error.js
+++ b/src/handle-error.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const stripAnsi = require('strip-ansi');
 const slscVersion = require('../package').version;
 const tokenizeException = require('./utils/tokenize-exception');
 const colors = require('./cli/colors');
 
-module.exports = async (exception, logger) => {
+module.exports = (exception, logger) => {
   const exceptionTokens = tokenizeException(exception);
   const isUserError = exceptionTokens.isUserError;
 
@@ -24,9 +23,8 @@ module.exports = async (exception, logger) => {
   logger.log(colors.darkGray(detailsTextTokens.join('\n')));
   logger.log();
 
-  const errorMsg = stripAnsi(
-    exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message
-  );
+  const errorMsg =
+    exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message;
   logger.writeText(`${colors.red('Error:')}\n${errorMsg}`);
 
   process.exitCode = 1;

--- a/src/index.js
+++ b/src/index.js
@@ -235,6 +235,19 @@ const runComponents = async () => {
   // So we can properly count it
   configurationForTelemetry = clone(configuration);
 
+  // Catch early Framework CLI-wide options that aren't supported here
+  // Since these are reserved options, we don't even want component-specific commands to support them
+  // so we detect these early for _all_ commands.
+  const unsupportedGlobalCliOptions = ['debug', 'config', 'param'];
+  unsupportedGlobalCliOptions.forEach((option) => {
+    if (options[option]) {
+      throw new ServerlessError(
+        `The "--${option}" option is not supported (yet) in Serverless Compose`,
+        'INVALID_CLI_OPTION'
+      );
+    }
+  });
+
   try {
     const componentsService = new ComponentsService(context, configuration);
     await componentsService.init();

--- a/src/index.js
+++ b/src/index.js
@@ -169,13 +169,6 @@ const resolveConfigurationVariables = async (configuration, stage) => {
   return resolvedConfiguration;
 };
 
-const mapMethodName = (methodName) => {
-  if (methodName === 'refresh-outputs') {
-    return 'refreshOutputs';
-  }
-  return methodName;
-};
-
 const runComponents = async () => {
   try {
     await spawnExt('serverless', ['--version']);
@@ -208,9 +201,6 @@ const runComponents = async () => {
     method = methods.join(':');
   }
   delete options._; // remove the method name if any
-
-  // Map CLI method names to internal method names
-  method = mapMethodName(method);
 
   const serverlessFile = getServerlessFile(process.cwd());
 
@@ -252,10 +242,7 @@ const runComponents = async () => {
     if (componentName) {
       await componentsService.invokeComponentCommand(componentName, method, options);
     } else {
-      if (typeof componentsService[method] !== 'function') {
-        throw new ServerlessError(`Command "${method}" not found`, 'COMMAND_NOT_FOUND');
-      }
-      await componentsService[method](options);
+      await componentsService.invokeGlobalCommand(method, options);
     }
 
     storeTelemetryLocally(


### PR DESCRIPTION
Addresses part of #62 

In order to [minimize wtf/minutes](https://www.osnews.com/story/19266/wtfsm/), this PR adds more detailed error messages for unknown global commands.

There are also specific messages for popular Framework commands, for example "package" or "offline", which we could expect users to run.

Finally, it also detects global CLI options we don't support yet (`--debug`, `--config` and `--param`).

I started adding more of these checks for CLI options of global commands (e.g. deploy, etc.) but I reverted my changes: I think the best way to validate CLI options will be via proper command declaration (via a "command" object), like in Serverless Framework. So I actually think the next step is having proper CLI command validation, instead of quick fixes. I'm not sure if we need to address this before v1 (I guess it will depend on time), I'll create a dedicated issue to discuss this.

---

Some examples:

<img width="720" alt="Screen-000251" src="https://user-images.githubusercontent.com/720328/161554235-ce3cd23a-624d-4ef4-8eb2-1dbf6dc12504.png">
<img width="995" alt="Screen-000253" src="https://user-images.githubusercontent.com/720328/161554904-e19a9bbf-c48c-4a2a-97e9-e88bbd410c06.png">
<img width="1037" alt="Screen-000254" src="https://user-images.githubusercontent.com/720328/161554912-0f648753-910b-48a1-8236-ec724366aece.png">
<img width="941" alt="image" src="https://user-images.githubusercontent.com/720328/161554940-17e03ada-9adb-4477-8157-79c9541c2489.png">

☝️ note that I intentionally did not use the gray color for "package" and "invoke" messages, because for these specific cases I wanted the extra information to be more visible to users (i.e. I don't consider that info secondary in those cases).