### PR TITLE
feat: Detect unsupported Framework versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "path2": "^0.1.0",
     "prettyoutput": "^1.2.0",
     "ramda": "^0.28.0",
+    "semver": "^7.3.5",
     "signal-exit": "^3.0.7",
     "strip-ansi": "^6.0.1",
     "traverse": "^0.6.6",

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ const path = require('path');
 const args = require('minimist')(process.argv.slice(2));
 const traverse = require('traverse');
 const { clone } = require('ramda');
-const spawnExt = require('child-process-ext/spawn');
 const utils = require('./utils');
 const renderHelp = require('./render-help');
 const Context = require('./Context');
@@ -177,15 +176,6 @@ const mapMethodName = (methodName) => {
 };
 
 const runComponents = async () => {
-  try {
-    await spawnExt('serverless', ['--version']);
-  } catch (err) {
-    throw new ServerlessError(
-      'Could not find the Serverless Framework CLI. Ensure Serverless Framework is installed before continuing.\nhttps://serverless.com/framework/docs/getting-started',
-      'SERVERLESS_COMMAND_NOT_AVAILABLE'
-    );
-  }
-
   if (args.help || args._[0] === 'help') {
     await renderHelp();
     return;

--- a/test/unit/src/components-service.test.js
+++ b/test/unit/src/components-service.test.js
@@ -142,7 +142,7 @@ describe('test/unit/src/components-service.test.js', () => {
       interactiveDisabled: true,
     };
     const mockedStateStorage = {
-      readServiceState: () => ({ id: 123 }),
+      readServiceState: () => ({ id: 123, detectedFrameworkVersion: '9.9.9' }),
       readComponentsOutputs: () => {
         return {
           resources: {
@@ -199,7 +199,7 @@ describe('test/unit/src/components-service.test.js', () => {
       interactiveDisabled: true,
     };
     const mockedStateStorage = {
-      readServiceState: () => ({ id: 123 }),
+      readServiceState: () => ({ id: 123, detectedFrameworkVersion: '9.9.9' }),
       readComponentOutputs: () => {
         return {
           somethingelse: '123',


### PR DESCRIPTION
Closes: #54 

I've decided to go with the approach where we check before running `exec` for the first time - it's used to actually call `serverless` binary and it will cover all different cases to how the component methods might be called. It's done separately for each component/service because the versions might differ between them.

Few examples of output:

Global parallel command
![6BFD5D41-A27E-469F-A8AD-53F9C932EB88_4_5005_c](https://user-images.githubusercontent.com/17499590/161556940-b7a169fd-6c41-4bba-8d72-5be93a737f80.jpeg)

Global graph-ordered command
![C787D2FC-1ACA-4D86-BC60-B4BA5A309578_4_5005_c](https://user-images.githubusercontent.com/17499590/161557059-d5820b41-e838-4aad-a5ae-dc2e19d5c388.jpeg)

Component-specific command
![1D0A1BF6-F917-49D5-A941-E864AE296F11_4_5005_c](https://user-images.githubusercontent.com/17499590/161557164-f5e755cc-8ed2-4bfe-bf5c-1db91a90e10c.jpeg)

