### PR TITLE
feat: Simplify `--help` to match Framework formatting

### DIFF
--- a/src/cli/Output.js
+++ b/src/cli/Output.js
@@ -44,10 +44,10 @@ class Output {
 
   /**
    * Writes text to stdout.
-   * @param {string} message
+   * @param {string} [message]
    * @param {string[]} [namespace]
    */
-  writeText(message, namespace = []) {
+  writeText(message = '', namespace = []) {
     message = this.namespaceLogMessage(message, namespace);
     this.safeWrite(message);
     this.writeToLogsFile(message);

--- a/src/render-help.js
+++ b/src/render-help.js
@@ -8,91 +8,62 @@ const commands = [
   {
     command: 'deploy',
     description: 'Deploy all services',
-    options: {
-      verbose: 'Show verbose logs',
-      stage: 'Stage of the service',
-    },
   },
   {
     command: 'remove',
     description: 'Remove all services',
-    options: {
-      verbose: 'Show verbose logs',
-      stage: 'Stage of the service',
-    },
   },
   {
     command: 'info',
     description: 'Display information about deployed services',
-    options: {
-      verbose: 'Show verbose logs',
-      stage: 'Stage of the service',
-    },
   },
   {
     command: 'logs',
     description: 'Output the logs for all services',
     options: {
-      verbose: 'Show verbose logs',
-      stage: 'Stage of the service',
       tail: 'Tail the log in real time',
     },
   },
   {
     command: 'outputs',
     description: 'Display outputs of deployed services',
-    options: {
-      stage: 'Stage of the service',
-    },
   },
   {
     command: 'refresh-outputs',
     description: 'Refresh the outptus for all services',
-    options: {
-      verbose: 'Show verbose logs',
-      stage: 'Stage of the service',
-    },
   },
 ];
 
-const formatCommand = (command) => {
+function formatLine(commandOrOption, description) {
   const indentFillLength = 25;
-
-  const commandLine = `${command.command} ${' '.repeat(
-    indentFillLength - command.command.length
-  )} ${colors.darkGray(command.description)}`;
-  const optionsLines = Object.entries(command.options).map(
-    ([key, desc]) =>
-      `  --${key} ${' '.repeat(indentFillLength - 4 - key.length)} ${colors.darkGray(desc)}`
-  );
-  return `${commandLine}\n${optionsLines.join('\n')}`;
-};
+  const spacing = ' '.repeat(indentFillLength - commandOrOption.length);
+  return `${commandOrOption} ${spacing} ${colors.darkGray(description)}`;
+}
 
 module.exports = async () => {
   const output = new Output(false);
-  output.log(`serverless-compose v${version}`);
-  output.log();
-  output.log(colors.darkGray('Usage'));
-  output.log();
-  output.log('serverless-compose <command> <options>');
-  output.log('slsc <command> <options>');
-  output.log();
-  output.log(colors.darkGray('Commands'));
-  output.log();
+  output.writeText(`Serverless Compose v${version}`);
+  output.writeText();
+  output.writeText(colors.darkGray('Usage'));
+  output.writeText('serverless-compose <command> <options>');
+  output.writeText('slsc <command> <options>');
+  output.writeText();
+  output.writeText(colors.darkGray('Service-specific commands'));
+  output.writeText('serverless-compose <command> <options> --service=<service-name>');
+  output.writeText(colors.darkGray('or the shortcut:'));
+  output.writeText('serverless-compose <service-name>:<command> <options>');
+  output.writeText();
+  output.writeText(colors.darkGray('Global options'));
+  output.writeText(formatLine('--verbose', 'Enable verbose logs'));
+  output.writeText(formatLine('--stage', 'Stage of the service'));
+  output.writeText();
+  output.writeText(colors.darkGray('Commands'));
 
   for (const command of commands) {
-    output.log(formatCommand(command));
-    output.log();
+    output.writeText(formatLine(command.command, command.description));
+    Object.entries(command.options ?? {}).forEach(([key, desc]) => {
+      output.writeText(formatLine(`  --${key}`, desc));
+    });
   }
-
-  output.log(colors.darkGray('Service-specific usage'));
-  output.log();
-  output.log('serverless-compose <command> <options> --service=<service-name>');
-  output.log('slsc <command> <options> --service=<service-name>');
-  output.log();
-  output.log(colors.darkGray('or alternatively'));
-  output.log();
-  output.log('serverless-compose <service-name>:<command>:<sub-command> <options>');
-  output.log('slsc <service-name>:<command>:<sub-command> <options>');
-  output.log();
+  output.writeText();
 };


### PR DESCRIPTION
I first looked at incorporating Compose help into the Framework help (for the future integration), but I _think_ (let's discuss this a bit later) that still have a full help dedicated to Compose makes sense.

So then I ended up comparing Framework and Compose help and noticed they were formatted slightly differently. I reworked the output to make them more consistent, which simplified it too.

## Framework help
<img width="637" alt="Screen-000284" src="https://user-images.githubusercontent.com/720328/162695588-282ef10e-c314-4d00-a4c4-0d65143f1ed6.png">

## Compose help
<img width="650" alt="Screen-000286" src="https://user-images.githubusercontent.com/720328/162695666-ee9cfb29-4040-40e8-9714-9683ede01a4b.png">
<img width="626" alt="Screen-000287" src="https://user-images.githubusercontent.com/720328/162695669-44ecd813-12ea-4db3-a594-065b1641c22d.png">


## New Compose help
<img width="642" alt="Screen-000285" src="https://user-images.githubusercontent.com/720328/162695545-5854b9ea-8218-4cf1-b23e-7a6348e5622b.png">

