### PR TITLE
fix: Improve non-progress errors

### DIFF
--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -20,7 +20,7 @@ const formatError = (e) => {
   if (formattedError.startsWith('Error:\n')) {
     formattedError = formattedError.slice(7);
   }
-  return formattedError;
+  return formattedError.trimEnd();
 };
 
 const resolveObject = (object, context) => {
@@ -448,9 +448,7 @@ class ComponentsService {
         if (this.context.progresses.exists(instance.id)) {
           this.context.progresses.error(instance.id, e);
         } else {
-          this.context.output.error(
-            `\nCommand failed for service "${instance.id}": ${formatError(e)}`
-          );
+          this.context.output.error(formatError(e), [instance.id]);
         }
         this.context.componentCommandsOutcomes[instance.id] = 'failure';
       }

--- a/src/cli/Progresses.js
+++ b/src/cli/Progresses.js
@@ -126,14 +126,18 @@ class Progresses {
    * @param {string|Error} [error]
    */
   error(name, error) {
-    error = error instanceof Error ? error.message : error;
+    const errorMessage = error instanceof Error ? error.message : error;
 
     if (!this.progresses[name]) throw Error(`No progress with name ${name}`);
     this.progresses[name].status = 'error';
     this.progresses[name].text = 'error';
     this.progresses[name].endTime = Date.now();
-    this.progresses[name].content = error;
+    this.progresses[name].content = errorMessage;
     this.updateSpinnerState();
+
+    if (error instanceof Error && error.stack) {
+      this.output.verbose(error.stack, [name]);
+    }
   }
 
   /**


### PR DESCRIPTION
Non-progress error formatting (inline):
![06DD4E63-F28E-44F1-859C-8BA854A34B9B](https://user-images.githubusercontent.com/17499590/162770013-bedbd8e8-d574-4581-9c17-53c334b83699.jpeg)

In-progress error formatting:
![59D90247-0E32-4FD0-BB75-7EA29D9E3CB0_4_5005_c](https://user-images.githubusercontent.com/17499590/162770142-a3dd6377-5623-4c7b-be69-b2d4bb535fc3.jpeg)

Details in verbose:
![D1E74C94-9D60-46D5-9B5A-1D3F7DCBF2AC_4_5005_c](https://user-images.githubusercontent.com/17499590/162770174-75087f26-f3c9-44e1-bf94-01c0df23b97d.jpeg)


I also have a more general question - should we flush all final states of progresses to verbose as well? Currently, we don't do that which might be confusing to users that expect full information in verbose logs cc @mnapoli 


Closes: #53 