### PR TITLE
refactor: Remove `name` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ _**BETA:** This repository contains a beta version of a new Serverless Framework
 - Run commands across multiple services
 
 ```yaml
-name: myapp
-
 services:
   subscriptions:
     path: subscriptions
@@ -82,9 +80,6 @@ _Note: You can also define your configuration with `serverless-compose.{ts,js,js
 In that new file, you can reference existing Serverless Framework projects by their **relative paths**:
 
 ```yaml
-# Name of the application
-name: myapp
-
 services:
   service-a:
     # Relative path to the Serverless Framework service

--- a/components/aws-cloudformation/serverless.js
+++ b/components/aws-cloudformation/serverless.js
@@ -34,7 +34,7 @@ class AwsCloudformation extends Component {
   constructor(id, context, inputs) {
     super(id, context, inputs);
 
-    this.stackName = `${this.appName}-${this.id}-${this.stage}`;
+    this.stackName = `${this.id}-${this.stage}`;
     this.region = this.inputs.region;
   }
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -6,8 +6,6 @@ class Component {
   /** @type {string} */
   id;
   /** @type {string} */
-  appName;
-  /** @type {string} */
   stage;
   /** @type {Record<string, any>} */
   inputs;
@@ -27,7 +25,6 @@ class Component {
    */
   constructor(id, context, inputs) {
     this.id = id || this.constructor.name;
-    this.appName = context.appName;
     this.stage = context.stage;
     this.inputs = inputs;
     this.context = context;

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -247,7 +247,7 @@ class ComponentsService {
 
   async deploy() {
     this.context.output.log();
-    this.context.output.log(`Deploying ${this.context.appName} to stage ${this.context.stage}`);
+    this.context.output.log(`Deploying to stage ${this.context.stage}`);
 
     // Pre-emptively add all components to the progress list
     Object.keys(this.allComponents).forEach((componentName) => {
@@ -267,7 +267,7 @@ class ComponentsService {
 
   async remove() {
     this.context.output.log();
-    this.context.output.log(`Removing stage ${this.context.stage} of ${this.context.appName}`);
+    this.context.output.log(`Removing stage ${this.context.stage}`);
 
     // Pre-emptively add all components to the progress list
     Object.keys(this.allComponents).forEach((componentName) => {
@@ -288,7 +288,7 @@ class ComponentsService {
 
   async refreshOutputs() {
     this.context.output.log();
-    this.context.output.log(`Refreshing outputs of ${this.context.appName}`);
+    this.context.output.log('Refreshing outputs');
 
     Object.keys(this.allComponents).forEach((componentName) => {
       this.context.progresses.add(componentName);

--- a/src/Context.js
+++ b/src/Context.js
@@ -27,7 +27,6 @@ class Context {
     this.stateStorage = new StateStorage(config.stage);
     this.stage = config.stage;
     this.id = undefined;
-    this.appName = config.appName;
 
     this.progresses = new Progresses(this.output);
     if (!config.verbose) {

--- a/src/configuration/validate.js
+++ b/src/configuration/validate.js
@@ -13,9 +13,9 @@ function validateConfiguration(configuration, configurationPath) {
     );
   }
 
-  if (!configuration.name || !configuration.services) {
+  if (!configuration.services) {
     throw new ServerlessError(
-      `Invalid configuration: "${configurationFilename}" must contain "name" and "services" properties.\n` +
+      `Invalid configuration: "${configurationFilename}" must contain "services" property.\n` +
         'Read about Serverless Compose configuration in the documentation: https://github.com/serverless/compose',
       'INVALID_CONFIGURATION'
     );
@@ -45,9 +45,7 @@ function validateConfiguration(configuration, configurationPath) {
     }
   });
 
-  const extraProperties = Object.keys(configuration).filter(
-    (key) => key !== 'name' && key !== 'services'
-  );
+  const extraProperties = Object.keys(configuration).filter((key) => key !== 'services');
   if (extraProperties.length > 0) {
     throw new ServerlessError(
       `Unrecognized property ${extraProperties.join(', ')} in "${configurationFilename}".\n` +

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,6 @@ const runComponents = async () => {
     stateRoot: path.join(process.cwd(), '.serverless'),
     verbose: options.verbose,
     stage: options.stage || 'dev',
-    appName: configuration.name,
   };
 
   context = new Context(contextConfig);

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -16,7 +16,6 @@ const getContext = async () => {
     root: process.cwd(),
     stateRoot: path.join(process.cwd(), '.serverless'),
     stage: 'dev',
-    appName: 'some-random-name',
     disableIO: true,
   };
   const context = new Context(contextConfig);

--- a/test/unit/src/components-service.test.js
+++ b/test/unit/src/components-service.test.js
@@ -37,7 +37,6 @@ describe('test/unit/src/components-service.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);
@@ -109,7 +108,6 @@ describe('test/unit/src/components-service.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);
@@ -138,7 +136,6 @@ describe('test/unit/src/components-service.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const mockedStateStorage = {
@@ -191,7 +188,6 @@ describe('test/unit/src/components-service.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const mockedStateStorage = {

--- a/test/unit/src/configuration/validate.test.js
+++ b/test/unit/src/configuration/validate.test.js
@@ -14,7 +14,6 @@ describe('test/unit/src/configuration/validate.test.js', () => {
     expect(() =>
       validateConfiguration(
         {
-          name: 'my-app',
           services: [],
           provider: {},
         },
@@ -25,7 +24,6 @@ describe('test/unit/src/configuration/validate.test.js', () => {
     expect(() =>
       validateConfiguration(
         {
-          name: 'my-app',
           services: [],
           foo: '',
         },
@@ -36,7 +34,6 @@ describe('test/unit/src/configuration/validate.test.js', () => {
     expect(() =>
       validateConfiguration(
         {
-          name: 'my-app',
           services: [],
         },
         configurationPath

--- a/test/unit/src/utils/telemetry/generate-payload.test.js
+++ b/test/unit/src/utils/telemetry/generate-payload.test.js
@@ -17,7 +17,6 @@ describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);
@@ -84,7 +83,6 @@ describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);
@@ -114,7 +112,6 @@ describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);
@@ -216,7 +213,6 @@ describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
       root: process.cwd(),
       stateRoot: path.join(process.cwd(), '.serverless'),
       stage: 'dev',
-      appName: 'some-random-name',
       disableIO: true,
     };
     const context = new Context(contextConfig);


### PR DESCRIPTION
Reported internally, remove `name` property as it currently does not serve any meaningful purpose and might cause confustion