### PR TITLE
refactor: Pass unique id with telemetry events

### DIFF
--- a/src/utils/telemetry/store-locally.js
+++ b/src/utils/telemetry/store-locally.js
@@ -20,7 +20,11 @@ function storeLocally(payload, context) {
 
   return (function self() {
     try {
-      return fse.writeJsonSync(join(cacheDirPath, id), { payload, timestamp: Date.now() });
+      // Additionally, we also append `id` to the payload to be used as $insert_id in Mixpanel to ensure event deduplication
+      return fse.writeJsonSync(join(cacheDirPath, id), {
+        payload: { ...payload, id },
+        timestamp: Date.now(),
+      });
     } catch (error) {
       if (error.code === 'ENOENT') {
         try {


### PR DESCRIPTION
Addresses: #52 

To be consistent with Framework events, compose events themselves are not under high risk for duplication.