### PR TITLE
refactor: Use single `gray` color in all places

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -30,7 +30,7 @@ class Context {
 
     this.progresses = new Progresses(this.output);
     if (!config.verbose) {
-      this.progresses.setFooterText(colors.darkGray('Press [?] to enable verbose logs'));
+      this.progresses.setFooterText(colors.gray('Press [?] to enable verbose logs'));
     }
   }
 

--- a/src/cli/colors.js
+++ b/src/cli/colors.js
@@ -8,7 +8,6 @@ const colorSupportLevel = chalk.supportsColor ? chalk.supportsColor.level : 0;
 module.exports = {
   white: chalk.white,
   gray: colorSupportLevel > 2 ? chalk.rgb(140, 141, 145) : chalk.gray,
-  darkGray: colorSupportLevel > 2 ? chalk.hex('#5F5F5F') : chalk.gray,
   red: colorSupportLevel > 2 ? chalk.rgb(253, 87, 80) : chalk.redBright,
   warning: chalk.rgb(255, 165, 0),
 };

--- a/src/handle-error.js
+++ b/src/handle-error.js
@@ -23,7 +23,7 @@ module.exports = (exception, output) => {
     'Bugs:        github.com/serverless/compose/issues'
   );
 
-  output.log(colors.darkGray(detailsTextTokens.join('\n')));
+  output.log(colors.gray(detailsTextTokens.join('\n')));
   output.log();
 
   const errorMsg =
@@ -31,7 +31,7 @@ module.exports = (exception, output) => {
   output.writeText(`${colors.red('Error:')}\n${errorMsg}`);
 
   output.log();
-  output.log(colors.darkGray('Verbose logs are available in ".serverless/compose.log"'));
+  output.log(colors.gray('Verbose logs are available in ".serverless/compose.log"'));
 
   process.exitCode = 1;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -168,9 +168,7 @@ const runComponents = async () => {
     // If at least one of the internal commands failed, we want to exit with error code 1
     if (Object.values(context.componentCommandsOutcomes).includes('failure')) {
       context.output.log();
-      context.output.log(
-        colors.darkGray('Verbose logs are available in ".serverless/compose.log"')
-      );
+      context.output.log(colors.gray('Verbose logs are available in ".serverless/compose.log"'));
       process.exit(1);
     } else {
       process.exit(0);

--- a/src/render-help.js
+++ b/src/render-help.js
@@ -37,27 +37,27 @@ const commands = [
 function formatLine(commandOrOption, description) {
   const indentFillLength = 25;
   const spacing = ' '.repeat(indentFillLength - commandOrOption.length);
-  return `${commandOrOption} ${spacing} ${colors.darkGray(description)}`;
+  return `${commandOrOption} ${spacing} ${colors.gray(description)}`;
 }
 
 module.exports = async () => {
   const output = new Output(false);
   output.writeText(`Serverless Compose v${version}`);
   output.writeText();
-  output.writeText(colors.darkGray('Usage'));
+  output.writeText(colors.gray('Usage'));
   output.writeText('serverless-compose <command> <options>');
   output.writeText('slsc <command> <options>');
   output.writeText();
-  output.writeText(colors.darkGray('Service-specific commands'));
+  output.writeText(colors.gray('Service-specific commands'));
   output.writeText('serverless-compose <command> <options> --service=<service-name>');
-  output.writeText(colors.darkGray('or the shortcut:'));
+  output.writeText(colors.gray('or the shortcut:'));
   output.writeText('serverless-compose <service-name>:<command> <options>');
   output.writeText();
-  output.writeText(colors.darkGray('Global options'));
+  output.writeText(colors.gray('Global options'));
   output.writeText(formatLine('--verbose', 'Enable verbose logs'));
   output.writeText(formatLine('--stage', 'Stage of the service'));
   output.writeText();
-  output.writeText(colors.darkGray('Commands'));
+  output.writeText(colors.gray('Commands'));
 
   for (const command of commands) {
     output.writeText(formatLine(command.command, command.description));

--- a/src/utils/process-backend-notification-request.js
+++ b/src/utils/process-backend-notification-request.js
@@ -8,5 +8,5 @@ module.exports = (notifications, output) => {
   if (!notification) return;
 
   output.log();
-  output.log(colors.darkGray(notification.message));
+  output.log(colors.gray(notification.message));
 };


### PR DESCRIPTION
Use the same color as in Framework - https://github.com/serverless/utils/blob/d5ed2f2639c2e47ca691da0cfd89d09d8bd5028f/lib/log-reporters/node/style.js#L12