### PR TITLE
fix: Replace white color to support white backgrounds

### DIFF
--- a/src/cli/Progresses.js
+++ b/src/cli/Progresses.js
@@ -201,8 +201,8 @@ class Progresses {
     let output = '\n';
     for (const [name, progress] of Object.entries(this.progresses)) {
       let symbol = ' ';
-      let componentColor = colors.white;
-      let statusColor = colors.white;
+      let componentColor = colors.foreground;
+      let statusColor = colors.foreground;
       if (progress.status === 'spinning') {
         symbol = frame;
       } else if (progress.status === 'success') {

--- a/src/cli/colors.js
+++ b/src/cli/colors.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const colorSupportLevel = chalk.supportsColor ? chalk.supportsColor.level : 0;
 
 module.exports = {
-  white: chalk.white,
+  foreground: chalk.reset,
   gray: colorSupportLevel > 2 ? chalk.rgb(140, 141, 145) : chalk.gray,
   red: colorSupportLevel > 2 ? chalk.rgb(253, 87, 80) : chalk.redBright,
   warning: chalk.rgb(255, 165, 0),


### PR DESCRIPTION
"white" is not a safe color because it doesn't work on white backgrounds. That "white" color was only used in progresses, which explains the screenshot below.

Instead we should have a "no color" kind of color, and it seems chalk.reset is the closest to that.

Before:
<img width="292" alt="Screen-000305" src="https://user-images.githubusercontent.com/720328/163356096-efdc7d86-9017-493f-86c4-c6623e5475f9.png">

After:

<img width="296" alt="Screen-000306" src="https://user-images.githubusercontent.com/720328/163356113-607f9117-eb77-4065-93ee-bf93195aeff9.png">

