### PR TITLE
feat: Detect unsupported CLI options and throw

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,13 @@ const ComponentsService = require('./ComponentsService');
 const generateTelemetryPayload = require('./utils/telemetry/generate-payload');
 const storeTelemetryLocally = require('./utils/telemetry/store-locally');
 const sendTelemetry = require('./utils/telemetry/send');
-const ServerlessError = require('./serverless-error');
 const handleError = require('./handle-error');
 const colors = require('./cli/colors');
 const resolveConfigurationVariables = require('./configuration/resolve-variables');
 const resolveConfigurationPath = require('./configuration/resolve-path');
 const readConfiguration = require('./configuration/read');
 const validateConfiguration = require('./configuration/validate');
+const validateOptions = require('./validate-options');
 const processBackendNotificationRequest = require('./utils/process-backend-notification-request');
 
 let options;
@@ -122,18 +122,7 @@ const runComponents = async () => {
   // So we can properly count it
   configurationForTelemetry = clone(configuration);
 
-  // Catch early Framework CLI-wide options that aren't supported here
-  // Since these are reserved options, we don't even want component-specific commands to support them
-  // so we detect these early for _all_ commands.
-  const unsupportedGlobalCliOptions = ['debug', 'config', 'param'];
-  unsupportedGlobalCliOptions.forEach((option) => {
-    if (options[option]) {
-      throw new ServerlessError(
-        `The "--${option}" option is not supported (yet) in Serverless Compose`,
-        'INVALID_CLI_OPTION'
-      );
-    }
-  });
+  validateOptions(options, method);
 
   try {
     const componentsService = new ComponentsService(context, configuration);

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const ServerlessError = require('./serverless-error');
+
+function validateCliOptions(options, method) {
+  // Catch early Framework CLI-wide options that aren't supported here
+  // Since these are reserved options, we don't even want component-specific commands to support them
+  // so we detect these early for _all_ commands.
+  const unsupportedGlobalCliOptions = ['debug', 'config', 'param'];
+  unsupportedGlobalCliOptions.forEach((option) => {
+    if (options[option]) {
+      throw new ServerlessError(
+        `The "--${option}" option is not supported (yet) in Serverless Compose\nYou can search and/or open feature requests here: https://github.com/serverless/compose'`,
+        'INVALID_GLOBAL_CLI_OPTION'
+      );
+    }
+  });
+
+  // Globally recognized options for global Compose methods
+  const supportedOptions = new Set(['verbose', 'stage']);
+  // We only validate methods that are explicitly recognized by Compose (excluding pass-through methods for Framework)
+
+  const recognizedMethods = new Set([
+    'deploy',
+    'remove',
+    'info',
+    'logs',
+    'outputs',
+    'refresh-outputs',
+  ]);
+
+  if (!recognizedMethods.has(method)) return;
+
+  if (method === 'logs') {
+    supportedOptions.add('tail');
+  }
+
+  const unrecognizedCliOptions = Object.keys(options).filter(
+    (option) => !supportedOptions.has(option)
+  );
+
+  if (!unrecognizedCliOptions.length) return;
+
+  let errorMessage = `Unrecognized CLI options: "--${unrecognizedCliOptions.join('", "--')}"`;
+
+  const frameworkSpecificCliOptions = new Set([
+    'aws-profile',
+    'region',
+    'app',
+    'org',
+    'force',
+    'package',
+  ]);
+  const usedFrameworkSpecificCliOptions = unrecognizedCliOptions.filter((option) =>
+    frameworkSpecificCliOptions.has(option)
+  );
+
+  if (usedFrameworkSpecificCliOptions.length) {
+    if (usedFrameworkSpecificCliOptions.length === 1) {
+      errorMessage += `\n\nCLI option "--${usedFrameworkSpecificCliOptions[0]}" is Serverless Framework-specific option that is not supported in Serverless Compose`;
+    } else {
+      errorMessage += `\n\nCLI options "--${usedFrameworkSpecificCliOptions.join(
+        '", "--'
+      )}" are Serverless Framework-specific options that are not supported in Serverless Compose`;
+    }
+    errorMessage +=
+      '\nYou can search and/or open feature requests here: https://github.com/serverless/compose';
+  }
+  throw new ServerlessError(errorMessage, 'UNRECOGNIZED_CLI_OPTIONS');
+}
+
+module.exports = validateCliOptions;

--- a/test/unit/src/validate-options.test.js
+++ b/test/unit/src/validate-options.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const expect = require('chai').expect;
+const validateOptions = require('../../../src/validate-options');
+
+describe('test/unit/src/validate-options.test.js', () => {
+  it('rejects globally unsupported options', () => {
+    expect(() => validateOptions({ debug: true }, 'deploy'))
+      .to.throw()
+      .and.have.property('code', 'INVALID_GLOBAL_CLI_OPTION');
+  });
+
+  it('rejects unrecognized options for native global Compose commands', () => {
+    expect(() => validateOptions({ package: '../something' }, 'deploy'))
+      .to.throw()
+      .and.have.property('code', 'UNRECOGNIZED_CLI_OPTIONS');
+  });
+
+  it('accepts custom options for non-native Compose commands', () => {
+    validateOptions({ package: '../something' }, 'invoke');
+  });
+});


### PR DESCRIPTION
Closes: #62 

Example error with unsupported options - some of them are recognized as the Framework options
![D627A69F-E8CA-4171-B4D9-AE525652087C_4_5005_c](https://user-images.githubusercontent.com/17499590/164002382-35e111db-7426-4765-8882-fb70243be646.jpeg)

