### PR TITLE
fix: Do not duplicate `stage` for Framework-specific commands

### DIFF
--- a/components/framework/serverless.js
+++ b/components/framework/serverless.js
@@ -29,13 +29,15 @@ class ServerlessFramework extends Component {
   // };
   // For now the workaround is to just pray that the command is correct and rely on validation from the Framework
   async command(command, options) {
-    const cliparams = Object.entries(options).map(([key, value]) => {
-      if (value === true) {
-        // Support flags like `--verbose`
-        return `--${key}`;
-      }
-      return `--${key}=${value}`;
-    });
+    const cliparams = Object.entries(options)
+      .filter(([key]) => key !== 'stage')
+      .map(([key, value]) => {
+        if (value === true) {
+          // Support flags like `--verbose`
+          return `--${key}`;
+        }
+        return `--${key}=${value}`;
+      });
     const args = [...command.split(':'), ...cliparams];
     return await this.exec('serverless', args, true);
   }


### PR DESCRIPTION
Closes: #97 