### PR TITLE
fix: More robust Framework outputs parsing

### DIFF
--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -98,8 +98,15 @@ describe('test/unit/components/framework/index.test.js', () => {
       },
       stdout: {
         on: (arg, cb) => {
+          // Simulate the output we get with Serverless Domain Manager
+          // https://github.com/serverless/compose/issues/105
           const data =
-            'region: us-east-1\n\nStack Outputs:\n  Key: Output\n\n SOME ADDITONAL NON-YAML TEXT';
+            'region: us-east-1\n\n' +
+            'Stack Outputs:\n' +
+            '  Key: Output\n' +
+            'Serverless Domain Manager:\n' +
+            '  Domain Name: example.com\n' +
+            '  ------------------------';
           if (arg === 'data') cb(data);
         },
       },


### PR DESCRIPTION
Fix #105 

Take into account scenarios where plugins might add extra CLI output right after `Stack Outputs:`.