### PR TITLE
fix: Handling of shorthand options for custom commands

### DIFF
--- a/components/framework/serverless.js
+++ b/components/framework/serverless.js
@@ -31,10 +31,15 @@ class ServerlessFramework extends Component {
   async command(command, options) {
     const cliparams = Object.entries(options)
       .filter(([key]) => key !== 'stage')
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (value === true) {
           // Support flags like `--verbose`
           return `--${key}`;
+        }
+        if (key.length === 1) {
+          // To handle shorthand notation like
+          // deploy -f function
+          return [`-${key}`, value];
         }
         return `--${key}=${value}`;
       });

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -173,7 +173,7 @@ describe('test/unit/components/framework/index.test.js', () => {
     const component = new FrameworkComponent('some-id', context, { path: 'custom-path' });
     component.state.detectedFrameworkVersion = '9.9.9';
 
-    await component.command('print', { key: 'val', flag: true });
+    await component.command('print', { key: 'val', flag: true, o: 'shortoption' });
 
     expect(spawnStub).to.be.calledOnce;
     expect(spawnStub.getCall(0).args[0]).to.equal('serverless');
@@ -181,6 +181,8 @@ describe('test/unit/components/framework/index.test.js', () => {
       'print',
       '--key=val',
       '--flag',
+      '-o',
+      'shortoption',
       '--stage',
       'dev',
     ]);


### PR DESCRIPTION
When investigating https://github.com/serverless/compose/issues/98 I've noticed that we're not handling shorthand options properly for custom Framework commands.
