### PR TITLE
Move all component API into a separate class

### DIFF
--- a/components/framework/serverless.js
+++ b/components/framework/serverless.js
@@ -48,58 +48,58 @@ class ServerlessFramework extends Component {
   }
 
   async deploy() {
-    this.startProgress('deploying');
+    this.context.startProgress('deploying');
 
     let cacheHash;
     if (this.inputs.cachePatterns) {
-      this.updateProgress('calculating changes');
+      this.context.updateProgress('calculating changes');
       cacheHash = await this.calculateCacheHash();
       const hasNoChanges =
-        JSON.stringify(this.inputs) === JSON.stringify(this.state.inputs) &&
-        cacheHash === this.state.cacheHash;
+        JSON.stringify(this.inputs) === JSON.stringify(this.context.state.inputs) &&
+        cacheHash === this.context.state.cacheHash;
       if (hasNoChanges) {
-        this.successProgress('no changes');
+        this.context.successProgress('no changes');
         return;
       }
-      this.updateProgress('deploying');
+      this.context.updateProgress('deploying');
     }
 
     const { stderr: deployOutput } = await this.exec('serverless', ['deploy']);
 
-    const hasOutputs = this.outputs && Object.keys(this.outputs).length > 0;
+    const hasOutputs = this.context.outputs && Object.keys(this.context.outputs).length > 0;
     const hasChanges = !deployOutput.includes('No changes to deploy. Deployment skipped.');
     // Skip retrieving outputs via `sls info` if we already have outputs (faster)
     if (hasChanges || !hasOutputs) {
-      await this.updateOutputs(await this.retrieveOutputs());
+      await this.context.updateOutputs(await this.retrieveOutputs());
     }
 
     // Save state
     if (this.inputs.cachePatterns) {
-      this.state.inputs = this.inputs;
-      this.state.cacheHash = cacheHash;
-      await this.save();
+      this.context.state.inputs = this.inputs;
+      this.context.state.cacheHash = cacheHash;
+      await this.context.save();
     }
 
     if (hasChanges) {
-      this.successProgress('deployed');
+      this.context.successProgress('deployed');
     } else {
-      this.successProgress('no changes');
+      this.context.successProgress('no changes');
     }
   }
 
   async remove() {
-    this.startProgress('removing');
+    this.context.startProgress('removing');
 
     await this.exec('serverless', ['remove']);
-    this.state = {};
-    await this.save();
-    await this.updateOutputs({});
-    this.successProgress('removed');
+    this.context.state = {};
+    await this.context.save();
+    await this.context.updateOutputs({});
+    this.context.successProgress('removed');
   }
 
   async info() {
     const { stdout: infoOutput } = await this.exec('serverless', ['info']);
-    this.writeText(infoOutput);
+    this.context.writeText(infoOutput);
   }
 
   async retrieveFunctions() {
@@ -117,7 +117,7 @@ class ServerlessFramework extends Component {
     if (Object.keys(functions).length === 0) return;
 
     if (options.tail) {
-      this.startProgress('logs');
+      this.context.startProgress('logs');
     }
 
     const promises = Object.keys(functions).map(async (functionName) => {
@@ -130,32 +130,32 @@ class ServerlessFramework extends Component {
           if (output.length > 0) {
             // Silence this error because it's not really an error: there are simply no logs
             if (output.includes('No existing streams for the function')) return;
-            this.writeText(output.trim(), [functionName]);
+            this.context.writeText(output.trim(), [functionName]);
           }
         });
       } catch (e) {
         // Silence this error because it's not really an error: there are simply no logs
         if (typeof e === 'string' && e.includes('No existing streams for the function')) return;
-        this.logError(e, [functionName]);
+        this.context.logError(e, [functionName]);
       }
     });
     await Promise.all(promises);
 
     if (options.tail) {
-      this.successProgress('no log streams to tail');
+      this.context.successProgress('no log streams to tail');
     }
   }
 
   async refreshOutputs() {
-    this.startProgress('refreshing outputs');
-    await this.updateOutputs(await this.retrieveOutputs());
-    this.successProgress('outputs refreshed');
+    this.context.startProgress('refreshing outputs');
+    await this.context.updateOutputs(await this.retrieveOutputs());
+    this.context.successProgress('outputs refreshed');
   }
 
   async ensureFrameworkVersion() {
     if (
-      !this.state.detectedFrameworkVersion ||
-      !doesSatisfyRequiredFrameworkVersion(this.state.detectedFrameworkVersion)
+      !this.context.state.detectedFrameworkVersion ||
+      !doesSatisfyRequiredFrameworkVersion(this.context.state.detectedFrameworkVersion)
     ) {
       let stdoutResult;
       try {
@@ -172,8 +172,8 @@ class ServerlessFramework extends Component {
         if (doesSatisfyRequiredFrameworkVersion(version)) {
           // Stored to avoid checking it on each invocation
           // We ignore edge case when someone downgrades or uninstalls serverless afterwards
-          this.state.detectedFrameworkVersion = version;
-          this.save();
+          this.context.state.detectedFrameworkVersion = version;
+          this.context.save();
         } else {
           throw new Error(
             `The installed version of Serverless Framework (${version}) is not supported by Compose. Please upgrade Serverless Framework to a version greater or equal to "${MINIMAL_FRAMEWORK_VERSION}"`
@@ -193,7 +193,7 @@ class ServerlessFramework extends Component {
   async exec(command, args, streamStdout = false, stdoutCallback = undefined) {
     await this.ensureFrameworkVersion();
     // Add stage
-    args.push('--stage', this.stage);
+    args.push('--stage', this.context.stage);
     // Add config file name if necessary
     if (this.inputs && this.inputs.config) {
       args.push('--config', this.inputs.config);
@@ -210,7 +210,7 @@ class ServerlessFramework extends Component {
       args = [process.pkg.entrypoint, ...args];
     }
 
-    this.logVerbose(`Running "${command} ${args.join(' ')}"`);
+    this.context.logVerbose(`Running "${command} ${args.join(' ')}"`);
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         cwd: this.inputs.path,
@@ -222,7 +222,7 @@ class ServerlessFramework extends Component {
       let allOutput = '';
       if (child.stdout) {
         child.stdout.on('data', (data) => {
-          this.logVerbose(data.toString().trim());
+          this.context.logVerbose(data.toString().trim());
           stdout += data;
           allOutput += data;
           if (stdoutCallback) {
@@ -232,7 +232,7 @@ class ServerlessFramework extends Component {
       }
       if (child.stderr) {
         child.stderr.on('data', (data) => {
-          this.logVerbose(data.toString().trim());
+          this.context.logVerbose(data.toString().trim());
           stderr += data;
           allOutput += data;
         });

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,36 +1,15 @@
 'use strict';
 
-const ServerlessError = require('./serverless-error');
-
 class Component {
   /**
    * @param {string} id
-   * @param {import('./Context')} context
+   * @param {import('./ComponentContext')} context
    * @param {Record<string, any>} inputs
    */
   constructor(id, context, inputs) {
-    this.id = id || this.constructor.name;
-    this.stage = context.stage;
+    this.id = id;
     this.inputs = inputs;
-    /** @private Let's try to keep the context private so that we limit the API surface for components */
     this.context = context;
-    /** @type {Record<string, any>} */
-    this.state = {};
-
-    if (typeof this.outputs === 'function') {
-      throw new ServerlessError(
-        `Cannot declare an "outputs" function in component "${this.id}"`,
-        'INVALID_COMPONENT_OUTPUTS'
-      );
-    }
-  }
-
-  // populating state is an async operation in most contexts
-  // and we can't run async operations in the constructor
-  // so we can't auto populate state on instance construction
-  async init() {
-    this.state = await this.context.stateStorage.readComponentState(this.id);
-    this.outputs = await this.context.stateStorage.readComponentOutputs(this.id);
   }
 
   async deploy() {
@@ -51,54 +30,6 @@ class Component {
 
   async refreshOutputs() {
     // To be implemented by components
-  }
-
-  async save() {
-    await this.context.stateStorage.writeComponentState(this.id, this.state);
-  }
-
-  /**
-   * @param {Record<string, any>} outputs
-   */
-  async updateOutputs(outputs) {
-    this.outputs = outputs;
-    await this.context.stateStorage.writeComponentOutputs(this.id, this.outputs);
-  }
-
-  /**
-   * @param {string} message
-   * @param {string[]} [namespace]
-   */
-  writeText(message, namespace = []) {
-    this.context.output.writeText(message, [this.id, ...namespace]);
-  }
-
-  /**
-   * @param {string} message
-   * @param {string[]} [namespace]
-   */
-  logVerbose(message, namespace = []) {
-    this.context.output.verbose(message, [this.id, ...namespace]);
-  }
-
-  /**
-   * @param {string|Error} error
-   * @param {string[]} [namespace]
-   */
-  logError(error, namespace = []) {
-    this.context.output.error(error, [this.id, ...namespace]);
-  }
-
-  startProgress(text) {
-    this.context.progresses.start(this.id, text);
-  }
-
-  updateProgress(text) {
-    this.context.progresses.update(this.id, text);
-  }
-
-  successProgress(text) {
-    this.context.progresses.success(this.id, text);
   }
 }
 

--- a/src/ComponentContext.js
+++ b/src/ComponentContext.js
@@ -1,0 +1,77 @@
+'use strict';
+
+class ComponentContext {
+  /**
+   * @param {string} componentId
+   * @param {import('./Context')} context
+   */
+  constructor(componentId, context) {
+    this.componentId = componentId;
+    this.stage = context.stage;
+    /** @type {Record<string, any>} */
+    this.state = {};
+    /** @type {Record<string, any>} */
+    this.outputs = {};
+
+    /** @private Let's keep the context private so that we limit the API surface for components */
+    this.context = context;
+  }
+
+  // populating state is an async operation in most contexts
+  // and we can't run async operations in the constructor
+  // so we can't auto populate state on instance construction
+  async init() {
+    this.state = await this.context.stateStorage.readComponentState(this.componentId);
+    this.outputs = await this.context.stateStorage.readComponentOutputs(this.componentId);
+  }
+
+  async save() {
+    await this.context.stateStorage.writeComponentState(this.componentId, this.state);
+  }
+
+  /**
+   * @param {Record<string, any>} outputs
+   */
+  async updateOutputs(outputs) {
+    this.outputs = outputs;
+    await this.context.stateStorage.writeComponentOutputs(this.componentId, this.outputs);
+  }
+
+  /**
+   * @param {string} message
+   * @param {string[]} [namespace]
+   */
+  writeText(message, namespace = []) {
+    this.context.output.writeText(message, [this.componentId, ...namespace]);
+  }
+
+  /**
+   * @param {string} message
+   * @param {string[]} [namespace]
+   */
+  logVerbose(message, namespace = []) {
+    this.context.output.verbose(message, [this.componentId, ...namespace]);
+  }
+
+  /**
+   * @param {string|Error} error
+   * @param {string[]} [namespace]
+   */
+  logError(error, namespace = []) {
+    this.context.output.error(error, [this.componentId, ...namespace]);
+  }
+
+  startProgress(text) {
+    this.context.progresses.start(this.componentId, text);
+  }
+
+  updateProgress(text) {
+    this.context.progresses.update(this.componentId, text);
+  }
+
+  successProgress(text) {
+    this.context.progresses.success(this.componentId, text);
+  }
+}
+
+module.exports = ComponentContext;

--- a/src/index.js
+++ b/src/index.js
@@ -184,6 +184,4 @@ const runComponents = async () => {
 
 module.exports = {
   runComponents,
-  Component,
-  Context,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ const args = require('minimist')(process.argv.slice(2));
 const { clone } = require('ramda');
 const renderHelp = require('./render-help');
 const Context = require('./Context');
-const Component = require('./Component');
 const ComponentsService = require('./ComponentsService');
 const generateTelemetryPayload = require('./utils/telemetry/generate-payload');
 const storeTelemetryLocally = require('./utils/telemetry/store-locally');

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -5,12 +5,16 @@ const proxyquire = require('proxyquire');
 const chai = require('chai');
 const sinon = require('sinon');
 const Context = require('../../../../src/Context');
+const ComponentContext = require('../../../../src/ComponentContext');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
+/**
+ * @returns {Promise<ComponentContext>}
+ */
 const getContext = async () => {
   const contextConfig = {
     root: process.cwd(),
@@ -20,7 +24,9 @@ const getContext = async () => {
   };
   const context = new Context(contextConfig);
   await context.init();
-  return context;
+  const componentContext = new ComponentContext('id', context);
+  await componentContext.init();
+  return componentContext;
 };
 
 describe('test/unit/components/framework/index.test.js', () => {
@@ -43,7 +49,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.deploy();
 
     expect(spawnStub).to.be.calledTwice;
@@ -53,8 +59,8 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(spawnStub.getCall(1).args[0]).to.equal('serverless');
     expect(spawnStub.getCall(1).args[1]).to.deep.equal(['info', '--verbose', '--stage', 'dev']);
     expect(spawnStub.getCall(1).args[2].cwd).to.equal('path');
-    expect(component.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
-    expect(component.outputs).to.deep.equal({ Key: 'Output' });
+    expect(context.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
+    expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
   it('correctly handles refresh-outputs', async () => {
@@ -76,15 +82,15 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.refreshOutputs();
 
     expect(spawnStub).to.be.calledOnce;
     expect(spawnStub.getCall(0).args[0]).to.equal('serverless');
     expect(spawnStub.getCall(0).args[1]).to.deep.equal(['info', '--verbose', '--stage', 'dev']);
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('path');
-    expect(component.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
-    expect(component.outputs).to.deep.equal({ Key: 'Output' });
+    expect(context.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
+    expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
   it('correctly handles refresh-outputs with malformed info outputs', async () => {
@@ -114,15 +120,15 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.refreshOutputs();
 
     expect(spawnStub).to.be.calledOnce;
     expect(spawnStub.getCall(0).args[0]).to.equal('serverless');
     expect(spawnStub.getCall(0).args[1]).to.deep.equal(['info', '--verbose', '--stage', 'dev']);
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('path');
-    expect(component.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
-    expect(component.outputs).to.deep.equal({ Key: 'Output' });
+    expect(context.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
+    expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
   it('correctly handles remove', async () => {
@@ -139,11 +145,11 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state = {
+    context.state = {
       key: 'val',
       detectedFrameworkVersion: '9.9.9',
     };
-    component.outputs = {
+    context.outputs = {
       outputkey: 'outputval',
     };
 
@@ -153,8 +159,8 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(spawnStub.getCall(0).args[0]).to.equal('serverless');
     expect(spawnStub.getCall(0).args[1]).to.deep.equal(['remove', '--stage', 'dev']);
     expect(spawnStub.getCall(0).args[2].cwd).to.equal('path');
-    expect(component.state).to.deep.equal({});
-    expect(component.outputs).to.deep.equal({});
+    expect(context.state).to.deep.equal({});
+    expect(context.outputs).to.deep.equal({});
   });
 
   it('correctly handles command', async () => {
@@ -171,7 +177,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'custom-path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
 
     await component.command('print', { key: 'val', flag: true, o: 'shortoption' });
 
@@ -203,7 +209,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'custom-path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
 
     await component.command('print', { key: 'val', flag: true, stage: 'dev' });
 
@@ -253,7 +259,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.logs({});
 
     expect(spawnStub).to.be.calledThrice;
@@ -296,7 +302,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.logs({});
 
     expect(spawnStub).to.be.calledOnce;
@@ -323,7 +329,7 @@ describe('test/unit/components/framework/index.test.js', () => {
 
     const context = await getContext();
     const component = new FrameworkComponent('some-id', context, { path: 'path' });
-    component.state.detectedFrameworkVersion = '9.9.9';
+    context.state.detectedFrameworkVersion = '9.9.9';
     await component.logs({ tail: true });
 
     expect(spawnStub).to.be.calledTwice;


### PR DESCRIPTION
The goal is to have a single point where the Compose package and components are coupled. This would be the `ComponentContext` class.

This prepares this work by moving all the component API into `ComponentContext`.