### PR TITLE
Log better stack traces for errors

### DIFF
--- a/src/handle-error.js
+++ b/src/handle-error.js
@@ -26,9 +26,17 @@ module.exports = (exception, output) => {
   output.log(colors.gray(detailsTextTokens.join('\n')));
   output.log();
 
-  const errorMsg =
-    exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message;
-  output.writeText(`${colors.red('Error:')}\n${errorMsg}`);
+  const shouldShowStackTrace = exceptionTokens.stack && !isUserError;
+  if (shouldShowStackTrace) {
+    // Only show the stack trace for "programmer" errors (i.e. not user errors)
+    output.writeText(`${colors.red('Error:')}\n${exceptionTokens.stack}`);
+  } else {
+    output.writeText(`${colors.red('Error:')}\n${exceptionTokens.message}`);
+    if (exceptionTokens.stack) {
+      // Log the stack trace to verbose so that users can always debug further if needed
+      output.verbose(exceptionTokens.stack);
+    }
+  }
 
   output.log();
   output.log(colors.gray('Verbose logs are available in ".serverless/compose.log"'));

--- a/src/serverless-error.js
+++ b/src/serverless-error.js
@@ -1,9 +1,25 @@
 'use strict';
 
+/**
+ * This class is for signaling user errors.
+ */
 class ServerlessError extends Error {
-  constructor(message, code) {
+  /**
+   * @param {string} message
+   * @param {string} code
+   * @param {unknown} [previous]
+   */
+  constructor(message, code, previous) {
     super(message);
     this.code = code;
+
+    // The ServerlessError class lets us pass a "previous" exception,
+    // i.e. the low-level error that we are wrapping with a better user message.
+    // We preserve the original stack trace (just like in Java or PHP)
+    // to ease debugging. See https://stackoverflow.com/q/42754270/245552
+    if (previous instanceof Error && previous.stack) {
+      this.stack += `\nFrom previous ${previous.stack}`;
+    }
   }
 }
 


### PR DESCRIPTION
1. Log stack traces to verbose for user errors
2. Allow logging the "previous" exception with ServerlessError

I made both of these changes while working on debugging this pattern in #124:

https://github.com/serverless/compose/blob/fa0306ad7ab1b9ab90d4e3cd007e4f8e2f8d684a/src/state/utils/get-compose-s3-state-bucket-name.js#L103-L114

When an error is thrown, for example by the CloudFormation deployment, then it is caught and re-thrown as `ServerlessError`. That gives the following output:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/720328/170662815-fb4a145d-0034-4822-a3e7-7680b4abb425.png">

Technically this was a bug, not sure how we can avoid wrapping that in `ServerlessError`, but anyway, that could have happened also with any CloudFormation error.

At this point I had no stack trace to debug. So that's where I added the first commit: log the stack trace to verbose for `ServerlessError`.

Here is the new output I got (in verbose):

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/720328/170663019-1c41916d-9245-433f-975e-b6bc64b80e61.png">

It's a little bit more helpful, but actually the stack trace points me to where `ServerlessError` is thrown, which isn't helpful at all. I want the original error.

In PHP (inspired by Java) there's a very common pattern of rethrowing an exception while keeping the "previous" exception and its stack trace. I had a look at it seems doable in JS: https://stackoverflow.com/q/42754270/245552 

So that's what the second commit is about: you can pass the "previous" exception (optionally), and you get it in the verbose output:

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/720328/170663327-c61f8b41-c0fe-48d0-953a-dfd87a4746f6.png">

Now I was able to actually pinpoint the problem. The output is surely verbose and a bit more complex, but this is the verbose mode and at least I have all the info I need 🤷 

Note that this PR doesn't contain an actual use case where I pass `previous` to `ServerlessError` because I used that in #124. We can make use of it later after everything is merged to `main`.