### PR TITLE
Validate component inputs via JSON schema

### DIFF
--- a/components/framework/configuration.js
+++ b/components/framework/configuration.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const configSchema = {
+  type: 'object',
+  properties: {
+    path: { type: 'string' },
+    region: { type: 'string' },
+    params: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+  required: ['path'],
+  additionalProperties: false,
+};
+
+module.exports = { configSchema };

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -8,6 +8,7 @@ const globby = require('globby');
 const path = require('path');
 const spawnExt = require('child-process-ext/spawn');
 const semver = require('semver');
+const { configSchema } = require('./configuration');
 
 const MINIMAL_FRAMEWORK_VERSION = '3.7.7';
 
@@ -310,5 +311,7 @@ class ServerlessFramework extends Component {
     return hasha(hashes.join(), { algorithm });
   }
 }
+
+ServerlessFramework.SCHEMA = configSchema;
 
 module.exports = ServerlessFramework;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@serverless/utils": "^6.6.0",
+    "ajv": "^8.11.0",
     "chalk": "^4.1.2",
     "child-process-ext": "^2.1.1",
     "ci-info": "^3.3.1",

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -487,7 +487,6 @@ class ComponentsService {
         const inputs = resolveObject(this.allComponents[alias].inputs, availableOutputs, method);
 
         try {
-          inputs.service = this.configuration.name;
           inputs.componentId = alias;
 
           const component = await loadComponent({
@@ -555,7 +554,6 @@ class ComponentsService {
         const availableOutputs = await this.context.stateStorage.readComponentsOutputs();
         const inputs = resolveObject(this.allComponents[alias].inputs, availableOutputs);
 
-        inputs.service = this.configuration.name;
         inputs.componentId = alias;
 
         this.allComponents[alias].instance = await loadComponent({

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -487,8 +487,6 @@ class ComponentsService {
         const inputs = resolveObject(this.allComponents[alias].inputs, availableOutputs, method);
 
         try {
-          inputs.componentId = alias;
-
           const component = await loadComponent({
             context: this.context,
             path: componentData.path,
@@ -553,8 +551,6 @@ class ComponentsService {
       const fn = async () => {
         const availableOutputs = await this.context.stateStorage.readComponentsOutputs();
         const inputs = resolveObject(this.allComponents[alias].inputs, availableOutputs);
-
-        inputs.componentId = alias;
 
         this.allComponents[alias].instance = await loadComponent({
           context: this.context,

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const colors = require('./cli/colors');
 const resolveConfigurationVariables = require('./configuration/resolve-variables');
 const resolveConfigurationPath = require('./configuration/resolve-path');
 const readConfiguration = require('./configuration/read');
-const validateConfiguration = require('./configuration/validate');
+const { validateConfiguration } = require('./configuration/validate');
 const validateOptions = require('./validate-options');
 const processBackendNotificationRequest = require('./utils/process-backend-notification-request');
 

--- a/src/load.js
+++ b/src/load.js
@@ -2,6 +2,7 @@
 
 const ComponentContext = require('./ComponentContext');
 const ServerlessError = require('./serverless-error');
+const { validateComponentInputs } = require('./configuration/validate');
 
 /**
  * @param {{
@@ -24,6 +25,15 @@ async function loadComponent({ context, path, alias, inputs }) {
   }
 
   const componentId = alias || ComponentClass.name;
+
+  // Validate inputs
+  // TODO: do this earlier, but this will require some heavier refactoring
+  // @ts-ignore
+  const configSchema = ComponentClass.SCHEMA;
+  if (configSchema !== undefined) {
+    validateComponentInputs(componentId, configSchema, inputs);
+  }
+
   const componentContext = new ComponentContext(componentId, context);
   await componentContext.init();
 


### PR DESCRIPTION
Let's discuss this idea this week.

Eventually, we want to validate configuration with JSON schema like in Serverless Framework. But until we have that, the lack of validation will provide a poor user experience for new components.

Related PR that adds JSON schema validation on the website component: https://github.com/serverless/components-core/pull/4