### PR TITLE
Move `path` validation in the Framework component

### DIFF
--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -8,6 +8,7 @@ const path = require('path');
 const spawnExt = require('child-process-ext/spawn');
 const semver = require('semver');
 const { configSchema } = require('./configuration');
+const ServerlessError = require('../../src/serverless-error');
 
 const MINIMAL_FRAMEWORK_VERSION = '3.7.7';
 
@@ -24,6 +25,13 @@ class ServerlessFramework {
     this.id = id;
     this.inputs = inputs;
     this.context = context;
+
+    if (path.relative(process.cwd(), inputs.path) === '') {
+      throw new ServerlessError(
+        `Service "${id}" cannot have a "path" that points to the root directory of the Serverless Framework Compose project`,
+        'INVALID_PATH_IN_SERVICE_CONFIGURATION'
+      );
+    }
   }
 
   // TODO:

--- a/src/configuration/validate.js
+++ b/src/configuration/validate.js
@@ -31,21 +31,6 @@ function validateConfiguration(configuration, configurationPath) {
         'INVALID_NON_OBJECT_SERVICE_CONFIGURATION'
       );
     }
-
-    if (!value.path) {
-      throw new ServerlessError(
-        `Invalid configuration: definition of "${key}" service must contain a "path" property.\n` +
-          'Read about Serverless Framework Compose configuration in the documentation: https://slss.io/docs-compose',
-        'MISSING_PATH_IN_SERVICE_CONFIGURATION'
-      );
-    }
-
-    if (path.relative(process.cwd(), value.path) === '') {
-      throw new ServerlessError(
-        `Definition of "${key}" service must contain a "path" property that does not point to the root directory of Serverless Framework Compose project`,
-        'INVALID_PATH_IN_SERVICE_CONFIGURATION'
-      );
-    }
   });
 
   // Provide a targeted error message if users use Framework options

--- a/test/unit/src/configuration/validate.test.js
+++ b/test/unit/src/configuration/validate.test.js
@@ -42,36 +42,6 @@ describe('test/unit/src/configuration/validate.test.js', () => {
       .and.have.property('code', 'INVALID_NON_OBJECT_SERVICE_CONFIGURATION');
   });
 
-  it('rejects configuration of specific services that do not have path defined', () => {
-    expect(() =>
-      validateConfiguration(
-        {
-          services: {
-            service: {},
-          },
-        },
-        configurationPath
-      )
-    )
-      .to.throw()
-      .and.have.property('code', 'MISSING_PATH_IN_SERVICE_CONFIGURATION');
-  });
-
-  it('rejects configuration of specific services that have path definition of root compose service', () => {
-    expect(() =>
-      validateConfiguration(
-        {
-          services: {
-            service: { path: '.' },
-          },
-        },
-        configurationPath
-      )
-    )
-      .to.throw()
-      .and.have.property('code', 'INVALID_PATH_IN_SERVICE_CONFIGURATION');
-  });
-
   it('rejects configuration that contains Framework-specific properties', () => {
     expect(() =>
       validateConfiguration(


### PR DESCRIPTION
The following constraint:

- `path` is required
- `path` cannot be `.`

Only apply to Framework services. They shouldn't apply to other components.

The only downside here is that validation of these rules will happen when each Framework component is instantiated (unfortunately).

[SF-18](https://serverlessinc.atlassian.net/browse/SF-18)