### PR TITLE
fix: Remove unneeded index from progress footer

### DIFF
--- a/src/cli/Progresses.js
+++ b/src/cli/Progresses.js
@@ -245,7 +245,7 @@ class Progresses {
     }
 
     if (this.footerText) {
-      output += `\n${this.footerText.trim()}`;
+      output += `\n${this.footerText.trim()}\r`;
     }
 
     output = this.wrapMultilineText(output);


### PR DESCRIPTION
Before
![953E120C-CF51-4B3F-9FF0-8496B226114B_4_5005_c](https://user-images.githubusercontent.com/17499590/172434348-91780063-ecf4-4e9d-9e19-d07d1e849a24.jpeg)

After
![1DE39751-6FD9-4888-94AC-75761FF1D141_4_5005_c](https://user-images.githubusercontent.com/17499590/172434402-ae3000a5-118f-4b7d-827a-617cca1cc489.jpeg)

