### PR TITLE
feat: Add `package` command

### DIFF
--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -116,6 +116,25 @@ class ServerlessFramework {
     this.context.successProgress('removed');
   }
 
+  async package() {
+    this.context.startProgress('packaging');
+
+    await this.exec('serverless', ['package']);
+
+    const hasOutputs = this.context.outputs && Object.keys(this.context.outputs).length > 0;
+
+    // Skip retrieving outputs via `sls info` if we already have outputs (faster)
+    if (!hasOutputs) {
+      await this.context.updateOutputs(await this.retrieveOutputs());
+    }
+
+    // Save state
+    if (this.inputs.cachePatterns) {
+      this.context.state.inputs = this.inputs;
+      await this.context.save();
+    }
+  }
+
   async info() {
     const { stdout: infoOutput } = await this.exec('serverless', ['info']);
     this.context.writeText(infoOutput);

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -120,12 +120,6 @@ class ServerlessFramework {
     this.context.startProgress('packaging');
 
     await this.exec('serverless', ['package']);
-
-    // Save state
-    if (this.inputs.cachePatterns) {
-      this.context.state.inputs = this.inputs;
-      await this.context.save();
-    }
   }
 
   async info() {

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -120,6 +120,8 @@ class ServerlessFramework {
     this.context.startProgress('packaging');
 
     await this.exec('serverless', ['package']);
+
+    this.context.successProgress('packaged');
   }
 
   async info() {

--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -121,13 +121,6 @@ class ServerlessFramework {
 
     await this.exec('serverless', ['package']);
 
-    const hasOutputs = this.context.outputs && Object.keys(this.context.outputs).length > 0;
-
-    // Skip retrieving outputs via `sls info` if we already have outputs (faster)
-    if (!hasOutputs) {
-      await this.context.updateOutputs(await this.retrieveOutputs());
-    }
-
     // Save state
     if (this.inputs.cachePatterns) {
       this.context.state.inputs = this.inputs;

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -340,7 +340,15 @@ class ComponentsService {
   }
 
   async invokeGlobalCommand(command, options) {
-    const globalCommands = ['deploy', 'remove', 'info', 'logs', 'outputs', 'refresh-outputs', 'package'];
+    const globalCommands = [
+      'deploy',
+      'remove',
+      'info',
+      'logs',
+      'outputs',
+      'refresh-outputs',
+      'package',
+    ];
     // Specific error messages for popular Framework commands
     if (command === 'invoke') {
       throw new ServerlessError(

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -307,11 +307,11 @@ class ComponentsService {
     });
   }
 
-  async package() {
+  async package(options) {
     this.context.output.log();
     this.context.output.log(`Packaging for stage ${this.context.stage}`);
 
-    await this.invokeComponentsInParallel('package');
+    await this.invokeComponentsInParallel('package', options);
   }
 
   async logs(options) {

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -311,20 +311,7 @@ class ComponentsService {
     this.context.output.log();
     this.context.output.log(`Packaging for stage ${this.context.stage}`);
 
-    // Pre-emptively add all components to the progress list
-    Object.keys(this.allComponents).forEach((componentName) => {
-      this.context.progresses.add(componentName);
-    });
-
     await this.invokeComponentsInParallel('package');
-
-    // Resolve the status of components that were not packaged
-    Object.keys(this.allComponents).forEach((componentName) => {
-      if (this.context.progresses.isWaiting(componentName)) {
-        this.context.progresses.skipped(componentName);
-        this.context.componentCommandsOutcomes[componentName] = 'skip';
-      }
-    });
   }
 
   async logs(options) {

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -318,7 +318,7 @@ class ComponentsService {
 
     await this.executeComponentsGraph({ method: 'package', reverse: false });
 
-    // Resolve the status of components that were not deployed
+    // Resolve the status of components that were not packaged
     Object.keys(this.allComponents).forEach((componentName) => {
       if (this.context.progresses.isWaiting(componentName)) {
         this.context.progresses.skipped(componentName);

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -316,7 +316,9 @@ class ComponentsService {
       this.context.progresses.add(componentName);
     });
 
-    await this.executeComponentsGraph({ method: 'package', reverse: false });
+    await this.invokeComponentsInParallel('package');
+
+    // await this.executeComponentsGraph({ method: 'package', reverse: false });
 
     // Resolve the status of components that were not packaged
     Object.keys(this.allComponents).forEach((componentName) => {

--- a/src/ComponentsService.js
+++ b/src/ComponentsService.js
@@ -318,8 +318,6 @@ class ComponentsService {
 
     await this.invokeComponentsInParallel('package');
 
-    // await this.executeComponentsGraph({ method: 'package', reverse: false });
-
     // Resolve the status of components that were not packaged
     Object.keys(this.allComponents).forEach((componentName) => {
       if (this.context.progresses.isWaiting(componentName)) {

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -50,7 +50,7 @@ function validateCliOptions(options, method) {
     'app',
     'org',
     'force',
-    'package'
+    'package',
   ]);
   const usedFrameworkSpecificCliOptions = unrecognizedCliOptions.filter((option) =>
     frameworkSpecificCliOptions.has(option)

--- a/src/validate-options.js
+++ b/src/validate-options.js
@@ -27,6 +27,7 @@ function validateCliOptions(options, method) {
     'logs',
     'outputs',
     'refresh-outputs',
+    'package',
   ]);
 
   if (!recognizedMethods.has(method)) return;
@@ -49,7 +50,7 @@ function validateCliOptions(options, method) {
     'app',
     'org',
     'force',
-    'package',
+    'package'
   ]);
   const usedFrameworkSpecificCliOptions = unrecognizedCliOptions.filter((option) =>
     frameworkSpecificCliOptions.has(option)

--- a/test/unit/components/framework/index.test.js
+++ b/test/unit/components/framework/index.test.js
@@ -65,6 +65,36 @@ describe('test/unit/components/framework/index.test.js', () => {
     expect(context.outputs).to.deep.equal({ Key: 'Output' });
   });
 
+  it('correctly handles package', async () => {
+    const spawnStub = sinon.stub().returns({
+      on: (arg, cb) => {
+        if (arg === 'close') cb(0);
+      },
+      stdout: {
+        on: (arg, cb) => {
+          const data = 'region: us-east-1\n\nStack Outputs:\n  Key: Output';
+          if (arg === 'data') cb(data);
+        },
+      },
+      kill: () => {},
+    });
+    const FrameworkComponent = proxyquire('../../../../components/framework/index.js', {
+      'cross-spawn': spawnStub,
+    });
+
+    const context = await getContext();
+    const component = new FrameworkComponent('some-id', context, { path: 'path' });
+    context.state.detectedFrameworkVersion = '9.9.9';
+    await component.package();
+
+    expect(spawnStub).to.be.calledOnce;
+    expect(spawnStub.getCall(0).args[0]).to.equal('serverless');
+    expect(spawnStub.getCall(0).args[1]).to.deep.equal(['package', '--stage', 'dev']);
+    expect(spawnStub.getCall(0).args[2].cwd).to.equal('path');
+    expect(context.state).to.deep.equal({ detectedFrameworkVersion: '9.9.9' });
+    expect(context.outputs).to.deep.equal({ Key: 'Output' });
+  });
+
   it('correctly handles refresh-outputs', async () => {
     const spawnStub = sinon.stub().returns({
       on: (arg, cb) => {


### PR DESCRIPTION
This PR adds the ability to run `serverless package` in the context of `serverless compose`.

The context for why this is a useful addition: https://serverless-contrib.slack.com/archives/CA4QT5VU3/p1658415216244289

Copy of slack message:

```
[Chris Hinds]
 [Yesterday at 3:53 PM]
Is there any way yet to just run package using serverless compose? i.e. one single command to package all services in the compose file
2 replies

[Chris Hinds]
  [18 hours ago]
For context as to why this would be useful. We currently run snapshot test and running the serverless package command which allows us to snapshot the outputted cloudformation.
We are also using serverless compose and would like to start using the params option within compose so we can pass params between services and create necessary dependencies.
If compose allows you to package all of the services then we could run our snapshots against the outputted cloudformation and not have to resort to running the serverless package command inside of each service directory (which kind of defeats the point of serverless compose IMO)


[Chris Hinds]
  [< 1 minute ago]
PR adding the package functionality to compose here https://github.com/serverless/compose/pull/150
```

A new test has been added to ensure the correct execution of the `package` command.