### PR TITLE
fix: add ability to use interactive stream with deploy and remove fun…

### DIFF
--- a/components/framework/index.js
+++ b/components/framework/index.js
@@ -84,10 +84,10 @@ class ServerlessFramework {
       this.context.updateProgress('deploying');
     }
 
-    const { stderr: deployOutput } = await this.exec('serverless', ['deploy']);
+    const { stderr: deployOutput } = await this.exec('serverless', ['deploy'], true);
 
     const hasOutputs = this.context.outputs && Object.keys(this.context.outputs).length > 0;
-    const hasChanges = !deployOutput.includes('No changes to deploy. Deployment skipped.');
+    const hasChanges = !deployOutput.includes('Change set did not include any changes to be deployed.');
     // Skip retrieving outputs via `sls info` if we already have outputs (faster)
     if (hasChanges || !hasOutputs) {
       await this.context.updateOutputs(await this.retrieveOutputs());
@@ -110,7 +110,7 @@ class ServerlessFramework {
   async remove() {
     this.context.startProgress('removing');
 
-    await this.exec('serverless', ['remove']);
+    await this.exec('serverless', ['remove'], true);
     this.context.state = {};
     await this.context.save();
     await this.context.updateOutputs({});


### PR DESCRIPTION
Hello,
Following the #173 issue, Here's a PR with the needed changes so that a serverless plugin requiring user input will be able to run in a serverless compose project.

The change is setting the `streamStdout` as `true` when invoking `exec` function in `deploy` and `remove` functions.

In addition I changed the `no changes` check in the `deploy` function since the output was changed in the serverless framework and the output is now - 
`Change set did not include any changes to be deployed.`

Thank you,
Shira